### PR TITLE
Prevent autoUpdater throw error and add notify

### DIFF
--- a/main/updater.js
+++ b/main/updater.js
@@ -25,6 +25,13 @@ module.exports = () => {
         body: 'Found update for the app! Downloading...'
       })
     })
+    
+    autoUpdater.on('error', () => {
+      notify({
+        title: 'Update failed',
+        body: 'Unable to reach update server'
+      })
+    })
 
     return autoUpdater.checkForUpdates()
   }


### PR DESCRIPTION
When autoUpdater fails the following error is thrown: "A JavaScript error occurred in the main process". autoUpdater.on('error') added to notify failed update and prevent error to throw.